### PR TITLE
Suppress the user-agent from newer versions of urllib3

### DIFF
--- a/pycarwings2/pycarwings2.py
+++ b/pycarwings2/pycarwings2.py
@@ -122,7 +122,7 @@ class Session(object):
             url=BASE_URL + endpoint,
             data=params,
             headers={"User-Agent": ""}
-            ).prepare()
+        ).prepare()
 
         log.debug("invoking carwings API: %s" % req.url)
         log.debug("params: %s" % json.dumps(

--- a/pycarwings2/pycarwings2.py
+++ b/pycarwings2/pycarwings2.py
@@ -118,7 +118,11 @@ class Session(object):
         else:
             params["custom_sessionid"] = ""
 
-        req = Request('POST', url=BASE_URL + endpoint, data=params).prepare()
+        req = Request('POST',
+            url=BASE_URL + endpoint,
+            data=params,
+            headers={"User-Agent": ""}
+            ).prepare()
 
         log.debug("invoking carwings API: %s" % req.url)
         log.debug("params: %s" % json.dumps(

--- a/pycarwings2/pycarwings2.py
+++ b/pycarwings2/pycarwings2.py
@@ -118,7 +118,8 @@ class Session(object):
         else:
             params["custom_sessionid"] = ""
 
-        req = Request('POST',
+        req = Request(
+            'POST',
             url=BASE_URL + endpoint,
             data=params,
             headers={"User-Agent": ""}


### PR DESCRIPTION
Newer versions of urllib3, such as those being used by Home Assistant, automatically add a User-Agent header to the request. It seems, from trial and error, that sending over a `User-Agent` header breaks the API leading to responses as "INVALID PARAMS".

This pull request adds an additional parameter in the `_request` body to suppress the `User-Agent` header from being automatically filled.