### PR TITLE
Downgrade loglevel

### DIFF
--- a/pycarwings2/pycarwings2.py
+++ b/pycarwings2/pycarwings2.py
@@ -102,8 +102,8 @@ class Session(object):
     def _request_with_retry(self, endpoint, params):
         ret = self._request(endpoint, params)
 
-        if ("status" in ret) and (ret["status"] >= 400):
-            log.error(
+        if "status" in ret and ret["status"] >= 400:
+            log.info(
                 "carwings error; logging in and trying request again: %s" % ret)
             # try logging in again
             self.connect()


### PR DESCRIPTION
If the nissan servers force us to log in again, that's not an error because 99% of the time we will try again and succeed. It's only an error if it subsequently fails.

This "ERROR" is the only error in my home assistant log. Downgrading this will silence the warning in normal operation.