### PR TITLE
Add timeout when sending commands

### DIFF
--- a/pycarwings2/pycarwings2.py
+++ b/pycarwings2/pycarwings2.py
@@ -134,7 +134,7 @@ class Session(object):
 
         try:
             sess = requests.Session()
-            response = sess.send(req)
+            response = sess.send(req, timeout=600.0)
             log.debug('Response HTTP Status Code: {status_code}'.format(
                 status_code=response.status_code))
             log.debug('Response HTTP Response Body: {content}'.format(


### PR DESCRIPTION
Adding timeout to send command. Without explicit timeout the command may get stuck, like described in https://github.com/filcole/pycarwings2/issues/35
Fixes #35 